### PR TITLE
Make this a drop-in replacement for `docker build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A cli command written in Go that uses a Docker registry to store layer caches in order to speed up build times. Useful in CI pipelines.
 
-The tool parses the `Dockerfile` for the stage targets and attempts to pull respective images from the specified registry. Any images it finds are used as layer caches for the docker build. Updated images for each stage back are pushed back to the registry ready for the next build.
+The tool parses the `Dockerfile` for the stage targets and attempts to pull respective images from the specified registry. Any images it finds are used as layer caches for the docker build. Updated images for each stage are pushed back to the registry ready for the next build.
 
 ### Steps:
 
 1.  Parse `Dockerfile` looking for stages.
-1.  Attempts to pull an image for each stage.
-    1.  Image name is that supplied by `--tag` appended with stage name or number: e.g. my-registry/my-image-builder or my-registry/my-image-0
+1.  Attempt to pull an image for each stage.
+    1.  Image name is that supplied by `--tag` appended with stage name or number: e.g. `my-registry/my-image-builder` or `my-registry/my-image-0`
 1.  For every image found, pass a `--cache-from` directive to the build.
 1.  Tag the images created for each stage.
 1.  Push these images back to the registry.
@@ -25,11 +25,11 @@ go get github.com/redbadger/build-with-cache
 
 ## Usage:
 
-The usage of `build-with-cache` is similar to [`docker build`](https://docs.docker.com/engine/reference/commandline/build/), with the following exceptions:
+The usage of `build-with-cache` is identical to [`docker build`](https://docs.docker.com/engine/reference/commandline/build/), with the following exceptions:
 
 1.  the `--tag` flag must be specified if you want caching enabled.
 1.  the `--cache` flag can be used to specify a separate registry for storing the cache images.
-1.  any additional flags must be passed to the build using `--flags`.
+1.  all flags (except `--cache`) are passed unaltered to `docker build`.
 
 ## Examples:
 
@@ -40,14 +40,14 @@ The usage of `build-with-cache` is similar to [`docker build`](https://docs.dock
       --tag=my-registry/my-image
     ```
 
-1.  Build with tarred context on `stdin`, use a local Docker registry as the cache, and pass additional flags to pass to the build:
+1.  Build with tarred context on `stdin`, use a local Docker registry as the cache, and pass a `--build-arg` flag to the build:
 
     ```bash
     tar c .| build-with-cache - \
-      --tag=my-registry/my-image
       --cache=localhost:5000 \
       --file=Dockerfile \
-      --flags="--build-arg http_proxy=http://localhost:3128"
+      --tag=my-registry.example.com/my-image
+      --build-arg http_proxy=http://localhost:3128
     ```
 
 ## To build

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,11 @@ var rootCmd = &cobra.Command{
 	Long: `
 A cli command written in Go that uses a Docker registry to store layer caches in order to speed up build times. Useful in CI pipelines.
 
-The tool parses the Dockerfile for the stage targets and attempts to pull respective images from the specified registry. Any images it finds are used as layer caches for the docker build. Updated images for each stage back are pushed back to the registry ready for the next build.
+The tool parses the Dockerfile for the stage targets and attempts to pull respective images from the specified registry. Any images it finds are used as layer caches for the docker build. Updated images for each stage are pushed back to the registry ready for the next build.
+
+The usage is identical to 'docker build' except for the '--cache' flag.
+
+In order to use caching, a '--tag' must be specified, and be in a canonical form (e.g. example.com/repository)
 `,
 	Version: constants.Version,
 	Args:    cobra.ExactArgs(1),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,6 @@ var (
 	file    string
 	tag     string
 	cache   string
-	flags   string
 )
 
 var rootCmd = &cobra.Command{
@@ -34,8 +33,11 @@ In order to use caching, a '--tag' must be specified, and be in a canonical form
 	Version: constants.Version,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		err = root.Run(args[0], file, tag, cache, flags)
+		err = root.Run(args[0], file, tag, cache)
 		return
+	},
+	FParseErrWhitelist: cobra.FParseErrWhitelist{
+		UnknownFlags: true,
 	},
 }
 
@@ -54,7 +56,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&file, "file", "f", "Dockerfile", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 	rootCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "", "Name and optionally a tag in the ‘registry/name:tag’ format")
 	rootCmd.PersistentFlags().StringVar(&cache, "cache", "", "Optional registry to use for cache (e.g. localhost:5000)")
-	rootCmd.PersistentFlags().StringVar(&flags, "flags", "", "Additional flags (as a string) to pass to docker build")
 }
 
 func initConfig() {

--- a/root/build_test.go
+++ b/root/build_test.go
@@ -1,0 +1,51 @@
+package root
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_createCommand(t *testing.T) {
+	type args struct {
+		args []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			"creates build command when using space",
+			args{
+				[]string{
+					"--cache", "myregistry",
+					"--file", "Dockerfile",
+					"--tag", "mytag",
+					"--build-arg", "x=1",
+					".",
+				},
+			},
+			[]string{"docker", "build", "--file", "Dockerfile", "--tag", "mytag", "--build-arg", "x=1", "."},
+		},
+		{
+			"creates build command when using equals sign",
+			args{
+				[]string{
+					".",
+					"--cache=myregistry",
+					"--file=Dockerfile",
+					"--tag=mytag",
+					"--build-arg=x=1",
+				},
+			},
+			[]string{"docker", "build", ".", "--file=Dockerfile", "--tag=mytag", "--build-arg=x=1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := createCommand(tt.args.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("createCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/root/run.go
+++ b/root/run.go
@@ -20,7 +20,7 @@ func streamDockerMessages(dst io.Writer, src io.Reader) error {
 }
 
 // Run the root command
-func Run(contextDir, file, imgName, cache, flags string) (err error) {
+func Run(contextDir, file, imgName, cache string) (err error) {
 	ctx := context.Background()
 	cli, err := client.NewEnvClient()
 	if err != nil {
@@ -50,7 +50,7 @@ func Run(contextDir, file, imgName, cache, flags string) (err error) {
 		}
 	}
 
-	out, err := build(contextDir, file, imgName, flags, images)
+	out, err := build(contextDir, images)
 	if err != nil {
 		err = fmt.Errorf("Error running docker build: %s", err)
 		return

--- a/root/run.go
+++ b/root/run.go
@@ -37,6 +37,9 @@ func Run(contextDir, file, imgName, cache, flags string) (err error) {
 			return
 		}
 		stages, images, err = parseDockerfile(reader, imgName, cache)
+		if err != nil {
+			return
+		}
 		for _, stage := range stages {
 			img := images[stage]
 			fmt.Printf("Pulling: %s\n", img)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -303,12 +303,6 @@
 			"revisionTime": "2017-10-17T18:19:29Z"
 		},
 		{
-			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
-			"path": "github.com/inconshreveable/mousetrap",
-			"revision": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75",
-			"revisionTime": "2014-10-17T20:07:13Z"
-		},
-		{
 			"checksumSHA1": "NiPRC0JDsfCFir75S1TrFHPP8+M=",
 			"path": "github.com/magiconair/properties",
 			"revision": "2c9e9502788518c97fe44e8955cd069417ee89df",
@@ -361,11 +355,10 @@
 			"revisionTime": "2018-05-14T13:37:33Z"
 		},
 		{
-			"checksumSHA1": "bBcApTXYM9Tpa8FqSEIV1onOGYQ=",
-			"origin": "github.com/docker/docker/vendor/github.com/sirupsen/logrus",
+			"checksumSHA1": "ByFN6xh/YGP/D3DM9c8p0D9D1XM=",
 			"path": "github.com/sirupsen/logrus",
-			"revision": "a79d04ae55196f73d67eeb8a40cfbeb67fed95e9",
-			"revisionTime": "2018-05-14T13:37:33Z"
+			"revision": "90150a8ed11b6ce285e77e8af2b0109559ce4777",
+			"revisionTime": "2018-03-15T01:07:03Z"
 		},
 		{
 			"checksumSHA1": "F3JU4T4XXvZTRAcv6rhTao4QGos=",
@@ -386,10 +379,10 @@
 			"revisionTime": "2018-02-14T17:35:30Z"
 		},
 		{
-			"checksumSHA1": "VNUkFQcdmHCkMDIcFtqlxsQQlls=",
+			"checksumSHA1": "Xnlls27MEcxIHhpRdsiUa2BqcFk=",
 			"path": "github.com/spf13/cobra",
-			"revision": "c6c44e6fdcc30161c7f4480754da7230d01c06e3",
-			"revisionTime": "2018-03-01T18:15:57Z"
+			"revision": "1e58aa3361fd650121dceeedc399e7189c05674a",
+			"revisionTime": "2018-05-31T18:03:38Z"
 		},
 		{
 			"checksumSHA1": "+JFKK0z5Eutk29rUz1lEhLxHMfk=",
@@ -398,10 +391,10 @@
 			"revisionTime": "2018-01-09T13:55:06Z"
 		},
 		{
-			"checksumSHA1": "tfKmT8uovT9Ch2YyDJtti3egAB4=",
+			"checksumSHA1": "OJI0OgC5V8gZtfS1e0CDYMhkDNc=",
 			"path": "github.com/spf13/pflag",
-			"revision": "ee5fd03fd6acfd43e44aea0b4135958546ed8e73",
-			"revisionTime": "2018-02-20T14:32:36Z"
+			"revision": "3ebe029320b2676d667ae88da602a5f854788a8a",
+			"revisionTime": "2018-06-01T13:25:42Z"
 		},
 		{
 			"checksumSHA1": "GWX9W5F1QBqLZsS1bYsG3jXjb3g=",
@@ -410,11 +403,10 @@
 			"revisionTime": "2017-11-29T09:51:06Z"
 		},
 		{
-			"checksumSHA1": "+WzOFwhDdPcz5PYt7imWl71ekZY=",
-			"origin": "github.com/docker/docker/vendor/golang.org/x/crypto/ssh/terminal",
+			"checksumSHA1": "6U7dCaxxIMjf5V02iWgyAwppczw=",
 			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "a79d04ae55196f73d67eeb8a40cfbeb67fed95e9",
-			"revisionTime": "2018-05-14T13:37:33Z"
+			"revision": "91a49db82a88618983a78a06c1cbd4e00ab749ab",
+			"revisionTime": "2018-02-28T15:18:34Z"
 		},
 		{
 			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
@@ -438,17 +430,16 @@
 			"revisionTime": "2018-05-14T13:37:33Z"
 		},
 		{
-			"checksumSHA1": "+uhefBjafyiwITh1H7W6zSkm4G4=",
+			"checksumSHA1": "Gk/9ytbO+HdWjCAZIhn0RDxYIrQ=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "cc7307a45468e49eaf2997c890f14aa03a26917b",
 			"revisionTime": "2018-03-15T08:13:33Z"
 		},
 		{
 			"checksumSHA1": "eQq+ZoTWPjyizS9XalhZwfGjQao=",
-			"origin": "github.com/docker/docker/vendor/golang.org/x/sys/windows",
 			"path": "golang.org/x/sys/windows",
-			"revision": "a79d04ae55196f73d67eeb8a40cfbeb67fed95e9",
-			"revisionTime": "2018-05-14T13:37:33Z"
+			"revision": "cc7307a45468e49eaf2997c890f14aa03a26917b",
+			"revisionTime": "2018-03-15T08:13:33Z"
 		},
 		{
 			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
@@ -457,7 +448,7 @@
 			"revisionTime": "2018-02-22T12:58:23Z"
 		},
 		{
-			"checksumSHA1": "BCNYmf4Ek93G4lk5x3ucNi/lTwA=",
+			"checksumSHA1": "lN2xlA6Utu7tXy2iUoMF2+y9EUE=",
 			"path": "golang.org/x/text/unicode/norm",
 			"revision": "b7ef84aaf62aa3e70962625c80a571ae7c17cb40",
 			"revisionTime": "2018-02-22T12:58:23Z"


### PR DESCRIPTION
It's useful for `build-with-cache` to be a drop-in replacement for `docker build`. In other words, this should be a wrapper for `docker build` and pass all arguments and flags through to it. 

If the flags and arguments are the same for both (with the exception of `--cache`), then a CI system (where it's not possible to use a local cache) can setup the command like this:

```bash
$cmd='build-with-cache --cache=myCacheRegistry'
``` 
and a developer (who already has a local cache) can set up the build command like this: 
```bash
$cmd='docker build'
```
Whether locally or during CI, the tooling can then run the relevant build with the same flags.